### PR TITLE
feat: Persist workout settings to user profile (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to Garmin Sync.
 ## [Unreleased]
 
 ### Added
+- Persist workout settings to user profile (#3)
+  - Rest times and unilateral mode saved to database
+  - Auto-save on change (1000ms debounce)
+  - Subtle "Saved" indicator with retry on failure
 - Two-column exercise mapping UI (DEN-6)
   - Left: parsed exercise name, Right: Garmin mapping
   - Searchable dropdown with 2,000+ Garmin exercises (cmdk)

--- a/garmin-sync-web/supabase/migrations/005_workout_settings.sql
+++ b/garmin-sync-web/supabase/migrations/005_workout_settings.sql
@@ -1,0 +1,21 @@
+-- Add workout settings columns to profiles table
+-- These persist user preferences for the workout creation page
+
+-- Rest time between sets for major compound lifts (squat, bench, deadlift, etc.)
+ALTER TABLE profiles
+ADD COLUMN major_lift_rest_seconds INTEGER DEFAULT 90;
+
+-- Rest time between sets for accessory/isolation exercises
+ALTER TABLE profiles
+ADD COLUMN minor_lift_rest_seconds INTEGER DEFAULT 60;
+
+-- How to handle unilateral exercises (one side at a time):
+-- 'double_sets' = 3 sets becomes 6 sets (3 per side)
+-- 'double_reps' = 8 reps becomes 16 reps (8 per side)
+ALTER TABLE profiles
+ADD COLUMN unilateral_mode TEXT DEFAULT 'double_sets';
+
+-- Add constraint to ensure valid unilateral mode values
+ALTER TABLE profiles
+ADD CONSTRAINT valid_unilateral_mode
+CHECK (unilateral_mode IN ('double_sets', 'double_reps'));


### PR DESCRIPTION
## Summary
- Settings (rest times, unilateral mode) now persist to the user's profile
- Auto-saves with 1000ms debounce when any setting changes
- Retries failed saves twice before showing error
- Subtle "Saved" indicator near the Advanced Settings toggle

## Changes
- Added `major_lift_rest_seconds`, `minor_lift_rest_seconds`, `unilateral_mode` columns to profiles table
- Load settings from DB on page mount (fallback to defaults if null)
- Debounced auto-save with retry logic

## Test plan
- [ ] Fresh user sees default settings (90s major, 60s minor, double sets)
- [ ] Change settings → "Saving..." appears → "Saved" appears briefly
- [ ] Refresh page → settings persist
- [ ] Network error → retries twice, then shows "Failed to save"

Closes #3