### PR TITLE
feat: Show exercise qualifiers in Original Input column

### DIFF
--- a/garmin-sync-web/src/app/api/parse-workout/route.ts
+++ b/garmin-sync-web/src/app/api/parse-workout/route.ts
@@ -74,6 +74,7 @@ Output ONLY valid JSON with this structure:
   "exercises": [
     {
       "name": "exercise name (lowercase)",
+      "original_input": "Exercise Name (Qualifier) - exactly as written by user",
       "sets": 3,
       "reps": 10,
       "weight_lbs": 135,
@@ -90,6 +91,7 @@ Rules:
 - "135lbs" or "135 lbs" or "135#" or "@ 135" all mean weight in pounds
 - If workout has no name, generate one based on exercises (e.g., "Upper Body", "Push Day")
 - Normalize exercise names to common form (e.g., "DB bench" -> "dumbbell bench press")
+- IMPORTANT: Preserve the original_input field with the exercise name EXACTLY as written by the user, including any qualifiers like "(Warm-up)", "(Work)", "(Heavy)", etc. This helps distinguish duplicate exercises.
 - For farmer's walk/carry: use distance_meters instead of reps
   - "40 yards" = 37 meters, "50 yards" = 46 meters, "100 feet" = 30 meters
   - If distance given, set reps to 1 and include distance_meters

--- a/garmin-sync-web/src/components/exercise-mapping-row.tsx
+++ b/garmin-sync-web/src/components/exercise-mapping-row.tsx
@@ -17,6 +17,8 @@ import { GARMIN_EXERCISES } from '@/lib/garmin-exercises'
 
 export type Exercise = {
   name: string
+  /** Original exercise line from user input (preserves qualifiers like "Warm-up" or "Work") */
+  original_input?: string
   sets: number
   reps: number
   weight_lbs?: number
@@ -177,11 +179,11 @@ export function ExerciseMappingRow({ exercise, index, onChange, isLast }: Exerci
       {/* Two-column layout: Input → Mapping */}
       <div className="flex flex-col sm:flex-row sm:items-start gap-4">
 
-        {/* LEFT: Original input (read-only) */}
+        {/* LEFT: Original input (read-only) - shows qualifier if available */}
         <div className="sm:w-1/3 pt-2">
           <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 font-medium capitalize">
             <span className="w-1.5 h-1.5 rounded-full bg-slate-300 dark:bg-slate-600" />
-            {exercise.name}
+            {exercise.original_input ?? exercise.name}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add `original_input` field to Exercise type to preserve qualifiers like "(Warm-up)" or "(Work)"
- Update Gemini parser prompt to populate the new field
- Display `original_input` in the UI with fallback to `name`

## Test plan
- [ ] Parse a workout with "(Warm-up)" and "(Work)" qualifiers
- [ ] Verify qualifiers appear in Original Input column
- [ ] Verify existing workouts without qualifiers still display correctly

Closes #12