### PR TITLE
Add custom rest and timed exercise targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to Garmin Sync.
 ## [Unreleased]
 
 ### Added
+- Custom rest periods and timed exercise targets in the workout generator
+  - Per-exercise rest seconds can be edited directly in preview
+  - Exercise target mode now supports Reps, Time, and Distance
+  - Timed exercises like planks, wall sits, and battle ropes store `duration_seconds`
 - Persist workout settings to user profile (#3)
   - Rest times and unilateral mode saved to database
   - Auto-save on change (1000ms debounce)

--- a/garmin-sync-web/eslint.config.mjs
+++ b/garmin-sync-web/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "public/sw.js",
+    "public/workbox-*.js",
   ]),
 ]);
 

--- a/garmin-sync-web/scripts/generate-icons.js
+++ b/garmin-sync-web/scripts/generate-icons.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * Generates PWA icons using sharp
  * Run: node scripts/generate-icons.js

--- a/garmin-sync-web/src/app/activity/[id]/page.tsx
+++ b/garmin-sync-web/src/app/activity/[id]/page.tsx
@@ -28,8 +28,12 @@ type Activity = {
 
 type PlannedExercise = {
   name: string
+  target_type?: 'reps' | 'time' | 'distance'
   sets: number
   reps: number
+  duration_seconds?: number
+  distance_meters?: number
+  rest_seconds?: number
   weight_lbs?: number
   category?: string
   garmin_name?: string
@@ -134,7 +138,7 @@ export default function ActivityPage({ params }: { params: Promise<{ id: string 
 
   useEffect(() => {
     async function loadActivity() {
-      const { data, error } = await supabase
+      const { data } = await supabase
         .from('activities')
         .select('*')
         .eq('id', id)
@@ -219,6 +223,21 @@ export default function ActivityPage({ params }: { params: Promise<{ id: string 
       hour: 'numeric',
       minute: '2-digit',
     })
+  }
+
+  function formatPlannedTarget(ex: PlannedExercise): string {
+    const targetType = ex.target_type ||
+      (ex.distance_meters ? 'distance' : ex.duration_seconds ? 'time' : 'reps')
+
+    if (targetType === 'time') {
+      return `${ex.duration_seconds || 30} sec`
+    }
+
+    if (targetType === 'distance') {
+      return `${Math.round((ex.distance_meters || 0) * 1.094)} yd`
+    }
+
+    return `${ex.reps} reps`
   }
 
   if (loading) {
@@ -444,11 +463,16 @@ export default function ActivityPage({ params }: { params: Promise<{ id: string 
                               <span className="font-medium text-slate-900 dark:text-white">{ex.sets}</span> sets
                             </div>
                             <div>
-                              <span className="font-medium text-slate-900 dark:text-white">{ex.reps}</span> reps
+                              <span className="font-medium text-slate-900 dark:text-white">{formatPlannedTarget(ex)}</span>
                             </div>
                             {ex.weight_lbs && (
                               <div>
                                 @ <span className="font-medium text-slate-900 dark:text-white">{ex.weight_lbs}</span> lbs
+                              </div>
+                            )}
+                            {typeof ex.rest_seconds === 'number' && (
+                              <div>
+                                <span className="font-medium text-slate-900 dark:text-white">{ex.rest_seconds}</span>s rest
                               </div>
                             )}
                           </div>

--- a/garmin-sync-web/src/app/api/garmin/sync/route.ts
+++ b/garmin-sync-web/src/app/api/garmin/sync/route.ts
@@ -15,16 +15,7 @@ type GarminActivity = {
   }
 }
 
-type GarminExerciseSet = {
-  exerciseName: string
-  exerciseCategory: string
-  setOrder: number
-  reps: number | null
-  weight: number | null
-  duration: number | null
-}
-
-export async function POST(request: NextRequest) {
+export async function POST() {
   try {
     // Verify user is authenticated
     const supabase = await createClient()

--- a/garmin-sync-web/src/app/api/parse-workout/route.ts
+++ b/garmin-sync-web/src/app/api/parse-workout/route.ts
@@ -63,9 +63,6 @@ const EXERCISE_ALIASES: Record<string, string> = {
   'shrugs': 'shrug',
 }
 
-// Distance-based exercises (use meters instead of reps)
-const DISTANCE_EXERCISES = ['farmer walk', 'farmers walk', 'farmer carry', 'farmers carry', "farmer's walk", "farmer's carry"]
-
 const PARSE_PROMPT = `You are a workout parser. Convert the user's plain text workout description into structured JSON.
 
 Output ONLY valid JSON with this structure:
@@ -75,10 +72,12 @@ Output ONLY valid JSON with this structure:
     {
       "name": "exercise name (lowercase)",
       "original_input": "Exercise Name (Qualifier) - exactly as written by user",
+      "target_type": "reps",
       "sets": 3,
       "reps": 10,
+      "duration_seconds": null,
       "weight_lbs": 135,
-      "rest_seconds": 90,
+      "rest_seconds": null,
       "distance_meters": null
     }
   ]
@@ -86,19 +85,121 @@ Output ONLY valid JSON with this structure:
 
 Rules:
 - If no weight specified, omit weight_lbs
-- Default rest is 90 seconds unless specified
+- If no rest is specified, omit rest_seconds or set it to null. Do not invent a default rest.
+- If rest is specified, convert it to rest_seconds
 - "3x10" means 3 sets of 10 reps
 - "135lbs" or "135 lbs" or "135#" or "@ 135" all mean weight in pounds
 - If workout has no name, generate one based on exercises (e.g., "Upper Body", "Push Day")
 - Normalize exercise names to common form (e.g., "DB bench" -> "dumbbell bench press")
 - IMPORTANT: Preserve the original_input field with the exercise name EXACTLY as written by the user, including any qualifiers like "(Warm-up)", "(Work)", "(Heavy)", etc. This helps distinguish duplicate exercises.
+- Use target_type "reps" for normal rep-based exercises
+- Use target_type "time" for exercises done for seconds/minutes
+  - "plank 3x45 sec" -> sets: 3, reps: 1, target_type: "time", duration_seconds: 45
+  - "wall sit 4x1 min" -> sets: 4, reps: 1, target_type: "time", duration_seconds: 60
+  - "battle ropes 8x30s, rest 30s" -> target_type: "time", duration_seconds: 30, rest_seconds: 30
 - For farmer's walk/carry: use distance_meters instead of reps
+  - Use target_type "distance"
   - "40 yards" = 37 meters, "50 yards" = 46 meters, "100 feet" = 30 meters
   - If distance given, set reps to 1 and include distance_meters
-  - Example: "farmer's walk 3x40 yards @ 70lbs" -> sets: 3, reps: 1, distance_meters: 37, weight_lbs: 70
+  - Example: "farmer's walk 3x40 yards @ 70lbs" -> target_type: "distance", sets: 3, reps: 1, distance_meters: 37, weight_lbs: 70
 
 User input:
 `
+
+type TargetType = 'reps' | 'time' | 'distance'
+
+type ParsedExercise = {
+  name?: string
+  original_input?: string
+  target_type?: TargetType
+  sets?: number
+  reps?: number
+  duration_seconds?: number | null
+  weight_lbs?: number
+  rest_seconds?: number | null
+  distance_meters?: number | null
+  [key: string]: unknown
+}
+
+function asPositiveNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined
+  }
+  return value
+}
+
+function secondsFromValue(value: number, unit: string | undefined): number {
+  const normalized = (unit || 'sec').toLowerCase()
+  return Math.round(normalized.startsWith('m') ? value * 60 : value)
+}
+
+function parseDurationSeconds(source: string): number | undefined {
+  const withoutRest = source
+    .replace(/\brest(?:s)?\s*(?:for|:|=)?\s*\d+(?:\.\d+)?\s*(seconds?|secs?|sec|s|minutes?|mins?|min|m)?\b/gi, '')
+    .replace(/\d+(?:\.\d+)?\s*(seconds?|secs?|sec|s|minutes?|mins?|min|m)\s+rest\b/gi, '')
+  const match = withoutRest.match(/(\d+(?:\.\d+)?)\s*(seconds?|secs?|sec|s|minutes?|mins?|min|m)\b/i)
+  if (!match) return undefined
+  return secondsFromValue(Number(match[1]), match[2])
+}
+
+function hasExplicitRest(source: string): boolean {
+  return /\brest(?:s|ing)?\b/i.test(source) || /\br\s*[:=]\s*\d+/i.test(source)
+}
+
+function parseRestSeconds(source: string): number | undefined {
+  if (/\b(?:no|zero)\s+rest\b/i.test(source) || /\brest(?:s)?\s*(?:for|:|=)?\s*0\b/i.test(source)) {
+    return 0
+  }
+
+  const afterRest = source.match(/\brest(?:s)?\s*(?:for|:|=)?\s*(\d+(?:\.\d+)?)\s*(seconds?|secs?|sec|s|minutes?|mins?|min|m)?\b/i)
+  if (afterRest) return secondsFromValue(Number(afterRest[1]), afterRest[2])
+
+  const beforeRest = source.match(/(\d+(?:\.\d+)?)\s*(seconds?|secs?|sec|s|minutes?|mins?|min|m)\s+rest\b/i)
+  if (beforeRest) return secondsFromValue(Number(beforeRest[1]), beforeRest[2])
+
+  return undefined
+}
+
+function normalizeExerciseTarget(ex: ParsedExercise): void {
+  const source = `${ex.original_input || ''} ${ex.name || ''}`.trim()
+  const explicitTarget = ex.target_type === 'reps' || ex.target_type === 'time' || ex.target_type === 'distance'
+    ? ex.target_type
+    : undefined
+  const duration = asPositiveNumber(ex.duration_seconds) || parseDurationSeconds(source)
+  const distance = asPositiveNumber(ex.distance_meters)
+
+  if (hasExplicitRest(source)) {
+    const parsedRest = parseRestSeconds(source)
+    const modelRest = typeof ex.rest_seconds === 'number' && Number.isFinite(ex.rest_seconds) && ex.rest_seconds >= 0
+      ? Math.round(ex.rest_seconds)
+      : undefined
+    // Text like "no rest" must override any model-invented default.
+    ex.rest_seconds = parsedRest !== undefined ? parsedRest : modelRest ?? null
+  } else {
+    delete ex.rest_seconds
+  }
+
+  if (explicitTarget === 'distance' || (!explicitTarget && distance)) {
+    ex.target_type = 'distance'
+    ex.distance_meters = distance || 37
+    ex.duration_seconds = null
+    ex.reps = 1
+    return
+  }
+
+  if (explicitTarget === 'time' || (!explicitTarget && duration)) {
+    ex.target_type = 'time'
+    ex.duration_seconds = duration || 30
+    ex.distance_meters = null
+    ex.reps = 1
+    return
+  }
+
+  ex.target_type = 'reps'
+  ex.duration_seconds = null
+  ex.distance_meters = null
+  ex.reps = asPositiveNumber(ex.reps) || 10
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -129,7 +230,7 @@ export async function POST(request: NextRequest) {
         contents: [{ parts: [{ text: PARSE_PROMPT + text }] }],
         generationConfig: {
           temperature: 0.1, // Low for consistent parsing
-          maxOutputTokens: 1000,
+          maxOutputTokens: 1500,
         },
       }),
     })
@@ -156,6 +257,8 @@ export async function POST(request: NextRequest) {
       const exerciseWarnings: { exercise: string; message: string; suggestions: ExerciseSuggestion[] }[] = []
 
       for (const ex of parsed.exercises || []) {
+        normalizeExerciseTarget(ex)
+
         let nameLower = ex.name.toLowerCase().trim()
 
         // Check aliases first (e.g., "rdl" -> "romanian deadlift")

--- a/garmin-sync-web/src/app/dashboard/activities-section.tsx
+++ b/garmin-sync-web/src/app/dashboard/activities-section.tsx
@@ -29,6 +29,7 @@ export function ActivitiesSection() {
 
   useEffect(() => {
     loadActivities()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   async function loadActivities() {
@@ -84,7 +85,7 @@ export function ActivitiesSection() {
       } else {
         setMessage(data.error || 'Sync failed')
       }
-    } catch (err) {
+    } catch {
       setMessage('Network error')
     } finally {
       setSyncing(false)
@@ -280,4 +281,3 @@ export function ActivitiesSection() {
     </div>
   )
 }
-

--- a/garmin-sync-web/src/app/settings/garmin/page.tsx
+++ b/garmin-sync-web/src/app/settings/garmin/page.tsx
@@ -23,6 +23,7 @@ export default function GarminConnectPage() {
 
   useEffect(() => {
     checkConnectionStatus()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   async function checkConnectionStatus() {
@@ -106,7 +107,7 @@ export default function GarminConnectPage() {
         setError(data.error || 'Failed to connect to Garmin')
         setLoading(false)
       }
-    } catch (err) {
+    } catch {
       setError('Network error. Please try again.')
       setLoading(false)
     }

--- a/garmin-sync-web/src/app/signup/page.tsx
+++ b/garmin-sync-web/src/app/signup/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -15,7 +14,6 @@ export default function SignupPage() {
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
   const [loading, setLoading] = useState(false)
-  const router = useRouter()
   const supabase = createClient()
 
   const handleSignup = async (e: React.FormEvent) => {

--- a/garmin-sync-web/src/app/workout/new/page.tsx
+++ b/garmin-sync-web/src/app/workout/new/page.tsx
@@ -62,13 +62,6 @@ type UnilateralMode = 'double_sets' | 'double_reps'
 // Settings save status for UI feedback
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 
-// Default settings (used when user has no saved preferences)
-const DEFAULT_SETTINGS = {
-  majorLiftRest: 90,
-  minorLiftRest: 60,
-  unilateralMode: 'double_sets' as UnilateralMode,
-}
-
 export default function NewWorkoutPage() {
   return (
     <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading...</div>}>
@@ -121,6 +114,10 @@ function NewWorkoutContent() {
     if (!isUnilateral(exercise.name)) return exercise
 
     if (unilateralMode === 'double_sets') {
+      return { ...exercise, sets: exercise.sets * 2 }
+    } else if (exercise.target_type === 'time' && exercise.duration_seconds) {
+      return { ...exercise, duration_seconds: exercise.duration_seconds * 2 }
+    } else if (exercise.target_type === 'distance') {
       return { ...exercise, sets: exercise.sets * 2 }
     } else {
       return { ...exercise, reps: exercise.reps * 2 }
@@ -261,10 +258,17 @@ function NewWorkoutContent() {
         const workoutWithSettings = {
           ...data.parsed,
           exercises: data.parsed.exercises.map((ex: Exercise) => {
+            const targetType = ex.target_type ||
+              (ex.distance_meters ? 'distance' : ex.duration_seconds ? 'time' : 'reps')
+            const hasParsedRest = typeof ex.rest_seconds === 'number' && Number.isFinite(ex.rest_seconds)
             // First apply rest time
             const withRest = {
               ...ex,
-              rest_seconds: ex.rest_seconds || (isMajorLift(ex.name) ? majorLiftRest : minorLiftRest),
+              target_type: targetType,
+              reps: ex.reps || 1,
+              rest_seconds: hasParsedRest
+                ? Math.max(0, ex.rest_seconds)
+                : (isMajorLift(ex.name) ? majorLiftRest : minorLiftRest),
             }
             // Then apply unilateral mode
             return applyUnilateralMode(withRest)
@@ -674,11 +678,21 @@ Lateral Raises 3x15…`}
 function buildGarminWorkout(parsed: ParsedWorkout) {
   const steps: unknown[] = []
   let stepOrder = 1
+  const endConditions = {
+    reps: { conditionTypeId: Number(10), conditionTypeKey: 'reps' },
+    time: { conditionTypeId: Number(2), conditionTypeKey: 'time' },
+    lapButton: { conditionTypeId: Number(7), conditionTypeKey: 'lap.button' },
+  }
 
   for (const ex of parsed.exercises) {
+    const targetType = ex.target_type ||
+      ((ex.distance_meters && ex.distance_meters > 0) ? 'distance' :
+        (ex.duration_seconds && ex.duration_seconds > 0) ? 'time' : 'reps')
+
     // Distance-based exercises (farmer's walk, etc.) use Lap Button instead of distance
     // Garmin's strength mode doesn't support distance as end condition - use manual lap press
-    const isDistanceBased = ex.distance_meters && ex.distance_meters > 0
+    const isDistanceBased = targetType === 'distance'
+    const isTimeBased = targetType === 'time'
 
     // Custom exercises use "CORE" with the real name in description
     const isCustomExercise = ex.garmin_name === 'CORE' || !ex.garmin_name
@@ -698,12 +712,17 @@ function buildGarminWorkout(parsed: ParsedWorkout) {
       stepOrder: Number(stepOrder + 1),
       stepType: { stepTypeId: Number(3), stepTypeKey: 'interval' },
       // Distance exercises: use Lap Button (7) - user presses lap when done
+      // Timed exercises: use Time (2), matching existing successful rest timers
       // Reps exercises: use reps (10)
       endCondition: isDistanceBased
-        ? { conditionTypeId: Number(7), conditionTypeKey: 'lap.button' }
-        : { conditionTypeId: Number(10), conditionTypeKey: 'reps' },
-      // For lap button, no value needed; for reps, use rep count
-      ...(isDistanceBased ? {} : { endConditionValue: Number(ex.reps) }),
+        ? endConditions.lapButton
+        : isTimeBased
+          ? endConditions.time
+          : endConditions.reps,
+      // For lap button, no value needed; timed and reps targets need a value
+      ...(isDistanceBased ? {} : {
+        endConditionValue: Number(isTimeBased ? (ex.duration_seconds || 30) : ex.reps),
+      }),
       targetType: { workoutTargetTypeId: Number(1), workoutTargetTypeKey: 'no.target' },
       category: ex.category || 'CORE',
       exerciseName: ex.garmin_name || 'CORE',
@@ -719,8 +738,8 @@ function buildGarminWorkout(parsed: ParsedWorkout) {
       type: 'ExecutableStepDTO',
       stepOrder: Number(stepOrder + 2),
       stepType: { stepTypeId: Number(5), stepTypeKey: 'rest' },
-      endCondition: { conditionTypeId: Number(2), conditionTypeKey: 'time' },
-      endConditionValue: Number(ex.rest_seconds || 90),
+      endCondition: endConditions.time,
+      endConditionValue: Number(ex.rest_seconds ?? 90),
       strokeType: { strokeTypeId: Number(0) },
       equipmentType: { equipmentTypeId: Number(0) },
     }

--- a/garmin-sync-web/src/components/exercise-mapping-row.tsx
+++ b/garmin-sync-web/src/components/exercise-mapping-row.tsx
@@ -19,8 +19,10 @@ export type Exercise = {
   name: string
   /** Original exercise line from user input (preserves qualifiers like "Warm-up" or "Work") */
   original_input?: string
+  target_type?: 'reps' | 'time' | 'distance'
   sets: number
   reps: number
+  duration_seconds?: number
   weight_lbs?: number
   rest_seconds: number
   category?: string
@@ -40,21 +42,6 @@ export type ExerciseMappingRowProps = {
   /** Whether this is the last item in the list */
   isLast?: boolean
 }
-
-// -----------------------------------------------------------------------------
-// Constants
-// -----------------------------------------------------------------------------
-
-const REST_TIME_OPTIONS = [
-  { value: 0, label: 'None' },
-  { value: 30, label: '30s' },
-  { value: 45, label: '45s' },
-  { value: 60, label: '60s' },
-  { value: 75, label: '75s' },
-  { value: 90, label: '90s' },
-  { value: 120, label: '2m' },
-  { value: 180, label: '3m' },
-]
 
 // Build a flat list of exercises for the dropdown
 // Format: { key: "bench press", category: "BENCH_PRESS", garminName: "BARBELL_BENCH_PRESS", displayName: "Bench Press" }
@@ -77,8 +64,11 @@ export function ExerciseMappingRow({ exercise, index, onChange, isLast }: Exerci
   const [searchQuery, setSearchQuery] = useState('')
   const dropdownRef = useRef<HTMLDivElement>(null)
 
-  // Determine if this exercise uses distance
-  const mode: 'reps' | 'distance' = (exercise.distance_meters && exercise.distance_meters > 0) ? 'distance' : 'reps'
+  // Determine the target mode. Older saved workouts will not have target_type,
+  // so fall back from the fields they already store.
+  const mode: 'reps' | 'time' | 'distance' = exercise.target_type ||
+    ((exercise.distance_meters && exercise.distance_meters > 0) ? 'distance' :
+      (exercise.duration_seconds && exercise.duration_seconds > 0) ? 'time' : 'reps')
 
   useEffect(() => {
     if (!dropdownOpen) return
@@ -154,21 +144,51 @@ export function ExerciseMappingRow({ exercise, index, onChange, isLast }: Exerci
   }
 
   const handleRestChange = (value: string) => {
-    const rest = parseInt(value, 10) || 60
-    onChange(index, { ...exercise, rest_seconds: rest })
+    const rest = value === '' ? 0 : parseInt(value, 10)
+    onChange(index, { ...exercise, rest_seconds: Math.max(0, Number.isNaN(rest) ? 0 : rest) })
   }
 
   const handleDistanceChange = (value: string) => {
     const yards = parseInt(value, 10) || 0
     const meters = Math.round(yards * 0.9144)
-    onChange(index, { ...exercise, distance_meters: meters })
+    onChange(index, { ...exercise, target_type: 'distance', distance_meters: meters, reps: 1, duration_seconds: undefined })
   }
 
-  const handleModeChange = (newMode: 'reps' | 'distance') => {
-    if (newMode === 'distance' && !exercise.distance_meters) {
-      onChange(index, { ...exercise, distance_meters: 37, reps: 1 })
-    } else if (newMode === 'reps' && exercise.distance_meters) {
-      onChange(index, { ...exercise, distance_meters: undefined, reps: exercise.reps || 10 })
+  const handleDurationChange = (value: string) => {
+    const seconds = parseInt(value, 10) || 1
+    onChange(index, {
+      ...exercise,
+      target_type: 'time',
+      duration_seconds: Math.max(1, seconds),
+      distance_meters: undefined,
+    })
+  }
+
+  const handleModeChange = (newMode: 'reps' | 'time' | 'distance') => {
+    if (newMode === 'distance') {
+      onChange(index, {
+        ...exercise,
+        target_type: 'distance',
+        distance_meters: exercise.distance_meters || 37,
+        duration_seconds: undefined,
+        reps: 1,
+      })
+    } else if (newMode === 'time') {
+      onChange(index, {
+        ...exercise,
+        target_type: 'time',
+        duration_seconds: exercise.duration_seconds || 30,
+        distance_meters: undefined,
+        reps: 1,
+      })
+    } else {
+      onChange(index, {
+        ...exercise,
+        target_type: 'reps',
+        distance_meters: undefined,
+        duration_seconds: undefined,
+        reps: exercise.reps || 10,
+      })
     }
   }
 
@@ -251,7 +271,24 @@ export function ExerciseMappingRow({ exercise, index, onChange, isLast }: Exerci
             </span>
           </div>
 
-          {/* Sets, Reps/Distance, Weight row */}
+          {/* Target mode */}
+          <div className="inline-grid grid-cols-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 p-0.5 text-xs font-semibold">
+            {(['reps', 'time', 'distance'] as const).map((targetMode) => (
+              <button
+                key={targetMode}
+                type="button"
+                onClick={() => handleModeChange(targetMode)}
+                className={`px-2.5 py-1.5 rounded-md transition-colors capitalize ${
+                  mode === targetMode
+                    ? 'bg-white dark:bg-slate-800 text-indigo-600 dark:text-indigo-300 shadow-sm'
+                    : 'text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
+                }`}
+              >
+                {targetMode === 'distance' ? 'Dist' : targetMode}
+              </button>
+            ))}
+          </div>
+
           {/* Stats Row - wraps on mobile */}
           <div className="flex flex-wrap items-center gap-2 sm:gap-3 pt-2">
             {/* Sets */}
@@ -269,18 +306,11 @@ export function ExerciseMappingRow({ exercise, index, onChange, isLast }: Exerci
               />
             </div>
 
-            {/* Reps / Distance */}
+            {/* Reps / Time / Distance */}
             <div className="relative group">
-              <div className="absolute -top-2 left-0 w-full flex justify-center z-10">
-                <button
-                  type="button"
-                  onClick={() => handleModeChange(mode === 'reps' ? 'distance' : 'reps')}
-                  className="px-1.5 bg-white dark:bg-slate-900 text-[10px] font-semibold text-slate-500 hover:text-indigo-600 dark:hover:text-indigo-400 uppercase tracking-wider transition-colors border border-transparent hover:border-slate-200 dark:hover:border-slate-700 rounded cursor-pointer"
-                  title="Click to toggle Reps/Distance"
-                >
-                  {mode === 'reps' ? 'Reps' : 'Dist'}
-                </button>
-              </div>
+              <label className="absolute -top-2 left-2 px-1 bg-white dark:bg-slate-900 text-[10px] font-semibold text-slate-500 uppercase tracking-wider">
+                {mode === 'distance' ? 'Yards' : mode === 'time' ? 'Sec' : 'Reps'}
+              </label>
 
               {mode === 'reps' ? (
                 <input
@@ -291,6 +321,16 @@ export function ExerciseMappingRow({ exercise, index, onChange, isLast }: Exerci
                   onChange={(e) => handleRepsChange(e.target.value)}
                   className="w-16 sm:w-20 px-2 sm:px-3 py-2 border border-slate-200 dark:border-slate-700 rounded-lg text-center bg-transparent focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 transition-all font-mono text-sm"
                   placeholder="Reps"
+                />
+              ) : mode === 'time' ? (
+                <input
+                  type="number"
+                  min="1"
+                  max="9999"
+                  value={exercise.duration_seconds ?? 30}
+                  onChange={(e) => handleDurationChange(e.target.value)}
+                  className="w-16 sm:w-20 px-2 sm:px-3 py-2 border border-slate-200 dark:border-slate-700 rounded-lg text-center bg-transparent focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 transition-all font-mono text-sm"
+                  placeholder="Sec"
                 />
               ) : (
                 <div className="relative">
@@ -326,19 +366,16 @@ export function ExerciseMappingRow({ exercise, index, onChange, isLast }: Exerci
             {/* Rest */}
             <div className="relative group">
               <label className="absolute -top-2 left-2 px-1 bg-white dark:bg-slate-900 text-[10px] font-semibold text-slate-500 uppercase tracking-wider">
-                Rest
+                Rest Sec
               </label>
-              <select
+              <input
+                type="number"
+                min="0"
+                max="9999"
                 value={exercise.rest_seconds}
                 onChange={(e) => handleRestChange(e.target.value)}
-                className="w-16 sm:w-20 px-1 sm:px-2 py-2 border border-slate-200 dark:border-slate-700 rounded-lg bg-transparent focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 cursor-pointer text-sm text-center appearance-none"
-              >
-                {REST_TIME_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
+                className="w-20 sm:w-24 px-2 sm:px-3 py-2 border border-slate-200 dark:border-slate-700 rounded-lg text-center bg-transparent focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 transition-all font-mono text-sm"
+              />
             </div>
           </div>
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -1,5 +1,5 @@
 """Pydantic schemas for Garmin workout data."""
-from typing import Any
+from typing import Any, Literal
 from pydantic import BaseModel
 
 
@@ -7,8 +7,10 @@ class ExerciseInput(BaseModel):
     """Input for a single exercise."""
     category: str  # e.g., "BENCH_PRESS", "SQUAT", "CURL"
     exercise_name: str  # e.g., "BARBELL_BENCH_PRESS", "DUMBBELL_FLYE"
+    target_type: Literal["reps", "time", "distance"] | None = None
     sets: int = 3
     reps: int = 10
+    duration_seconds: int | None = None  # For timed exercises (planks, wall sits)
     rest_seconds: int = 60
     weight_lbs: float | None = None  # Optional preset weight
     distance_meters: float | None = None  # For distance-based exercises (farmer's carry)
@@ -48,6 +50,15 @@ def build_workout_json(workout: WorkoutInput) -> dict[str, Any]:
     step_order = 1
 
     for exercise in workout.exercises:
+        target_type = exercise.target_type
+        if target_type is None:
+            if exercise.distance_meters:
+                target_type = "distance"
+            elif exercise.duration_seconds:
+                target_type = "time"
+            else:
+                target_type = "reps"
+
         # Create a repeat group for each exercise (sets x reps)
         repeat_group = {
             "type": "RepeatGroupDTO",
@@ -62,63 +73,54 @@ def build_workout_json(workout: WorkoutInput) -> dict[str, Any]:
         }
         step_order += 1
 
-        # Exercise step - use distance for distance-based exercises, reps otherwise
-        if exercise.distance_meters:
-            # Distance-based exercise (farmer's carry, etc.)
-            exercise_step = {
-                "type": "ExecutableStepDTO",
-                "stepOrder": step_order,
-                "stepType": {
-                    "stepTypeId": 3,
-                    "stepTypeKey": "interval",
-                },
-                "endCondition": {
-                    "conditionTypeId": 3,
-                    "conditionTypeKey": "distance",
-                },
-                "endConditionValue": float(exercise.distance_meters),
-                "targetType": {
-                    "workoutTargetTypeId": 1,
-                    "workoutTargetTypeKey": "no.target",
-                },
-                "category": exercise.category,
-                "exerciseName": exercise.exercise_name,
-                "strokeType": {"strokeTypeId": 0},
-                "equipmentType": {"equipmentTypeId": 0},
-                "weightUnit": {
-                    "unitId": 9,
-                    "unitKey": "pound",
-                    "factor": 453.59237,
-                },
+        if target_type == "distance":
+            end_condition = {
+                "conditionTypeId": 7,
+                "conditionTypeKey": "lap.button",
             }
+            end_value = None
+        elif target_type == "time":
+            end_condition = {
+                "conditionTypeId": 2,
+                "conditionTypeKey": "time",
+            }
+            end_value = int(exercise.duration_seconds or 30)
         else:
-            # Reps-based exercise (standard)
-            exercise_step = {
-                "type": "ExecutableStepDTO",
-                "stepOrder": step_order,
-                "stepType": {
-                    "stepTypeId": 3,
-                    "stepTypeKey": "interval",
-                },
-                "endCondition": {
-                    "conditionTypeId": 10,
-                    "conditionTypeKey": "reps",
-                },
-                "endConditionValue": float(exercise.reps),
-                "targetType": {
-                    "workoutTargetTypeId": 1,
-                    "workoutTargetTypeKey": "no.target",
-                },
-                "category": exercise.category,
-                "exerciseName": exercise.exercise_name,
-                "strokeType": {"strokeTypeId": 0},
-                "equipmentType": {"equipmentTypeId": 0},
-                "weightUnit": {
-                    "unitId": 9,
-                    "unitKey": "pound",
-                    "factor": 453.59237,
-                },
+            end_condition = {
+                "conditionTypeId": 10,
+                "conditionTypeKey": "reps",
             }
+            end_value = int(exercise.reps)
+
+        exercise_step = {
+            "type": "ExecutableStepDTO",
+            "stepOrder": step_order,
+            "stepType": {
+                "stepTypeId": 3,
+                "stepTypeKey": "interval",
+            },
+            "endCondition": end_condition,
+            "targetType": {
+                "workoutTargetTypeId": 1,
+                "workoutTargetTypeKey": "no.target",
+            },
+            "category": exercise.category,
+            "exerciseName": exercise.exercise_name,
+            "strokeType": {"strokeTypeId": 0},
+            "equipmentType": {"equipmentTypeId": 0},
+            "weightUnit": {
+                "unitId": 9,
+                "unitKey": "pound",
+                "factor": 453.59237,
+            },
+        }
+
+        if end_value is not None:
+            exercise_step["endConditionValue"] = end_value
+
+        if target_type == "distance" and exercise.distance_meters:
+            yards = round(exercise.distance_meters * 1.094)
+            exercise_step["description"] = f"{yards} yds"
 
         if exercise.weight_lbs:
             exercise_step["weightValue"] = exercise.weight_lbs
@@ -138,7 +140,7 @@ def build_workout_json(workout: WorkoutInput) -> dict[str, Any]:
                 "conditionTypeId": 2,
                 "conditionTypeKey": "time",
             },
-            "endConditionValue": float(exercise.rest_seconds),
+            "endConditionValue": int(exercise.rest_seconds),
             "strokeType": {"strokeTypeId": 0},
             "equipmentType": {"equipmentTypeId": 0},
         }

--- a/thoughts/ledgers/CONTINUITY_CLAUDE-garmin-sync.md
+++ b/thoughts/ledgers/CONTINUITY_CLAUDE-garmin-sync.md
@@ -1,13 +1,25 @@
 # Session: garmin-sync
-Updated: 2026-01-24T15:03:48.035Z
+Updated: 2026-05-20
 
 ## Goal
 Public web app to plan strength workouts with AI, push to Garmin watch, track progress.
 
 ## State
 - Done: Phase 1-4, exercise mapping, security, DEN-6 mapping UI, review fixes, doc consolidation
-- Now: Ready for next feature
-- Next: DEN-7 (persist workout settings), Phase 5 (Gemini chatbot)
+- Done: Rotated Gemini API key on Vercel (Apr 8)
+- Now: Custom rest periods and timed exercise support implemented locally; Garmin/watch validation pending
+- Next: Run a logged-in parse/preview test with real app environment values, then push one timed workout to Garmin for acceptance testing
+
+## Active Plan (May 19)
+
+- Plan: `thoughts/shared/plans/2026-05-19-custom-rest-and-timed-exercises.md`
+- Request: Customer asked whether the generator can support custom rest periods and exercises performed for time.
+- Direction: Add arbitrary per-exercise rest editing and a third exercise target mode for timed work, alongside existing reps and distance modes.
+- Confirmed scope: per-exercise custom rest, simple seconds/minutes timed exercises only, real Garmin validation before release.
+- Payload note: use the app's existing working Garmin constants as source of truth (`reps` = 10, `time` = 2, `lap.button` = 7); do not follow conflicting condition ID notes from older research without a golden-master payload.
+- Implemented locally: parser prompt/normalizer, Reps/Time/Distance preview controls, per-exercise rest seconds, timed Garmin payload builders, planned-vs-actual display, lint cleanup, changelog entry.
+- Verification completed: `npm run lint`, `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-key GEMINI_API_KEY=dummy-gemini-key PYTHON_API_URL=http://localhost:8000 npm run build`, `.venv/bin/python -m py_compile src/*.py`, local `/workout/new` HTTP 200 via `npm run dev -- --webpack`, Chrome smoke test for the workout builder, and backend payload fixture check for reps/time/distance/custom-rest/zero-rest.
+- Validation still needed before release: logged-in parser preview using real environment values, then real Garmin push/watch test for a timed strength interval using `endCondition: time`.
 
 ## Documentation Consolidation (Jan 23)
 - Updated CHECKLIST.md - Phase 3, 4, Deployment all marked complete (was stale)
@@ -34,7 +46,7 @@ Public web app to plan strength workouts with AI, push to Garmin watch, track pr
 - **Vercel**: https://garmin-sync.vercel.app (Next.js)
 - **Render**: https://garmin-sync-api.onrender.com (FastAPI)
 - **GitHub**: densign01/garmin-sync
-- **Latest commit**: 02e3f5d (fix: click-outside + mode sync)
+- **Latest commit**: 74f8321 (Merge PR #27 - exercise qualifiers)
 
 ## Recent Features (Jan 21 - DEN-6)
 1. **Two-column mapping UI**: Input → Garmin exercise mapping
@@ -69,7 +81,7 @@ Public web app to plan strength workouts with AI, push to Garmin watch, track pr
 5. **Mapping UI**: Two-column layout with searchable dropdown (cmdk) and editable fields
 
 ## Working Set
-- Project: `/Users/densign/Documents/Coding-Projects/claude-cloud/garmin-sync/`
+- Project: `/Users/densign/Documents/Coding-Projects/garmin-sync/`
 - Branch: `master`
 - Key files:
   - `src/main.py` (Render - encryption, CORS, auth)

--- a/thoughts/ledgers/CONTINUITY_CLAUDE-garmin-sync.md
+++ b/thoughts/ledgers/CONTINUITY_CLAUDE-garmin-sync.md
@@ -8,7 +8,7 @@ Public web app to plan strength workouts with AI, push to Garmin watch, track pr
 - Done: Phase 1-4, exercise mapping, security, DEN-6 mapping UI, review fixes, doc consolidation
 - Done: Rotated Gemini API key on Vercel (Apr 8)
 - Now: Custom rest periods and timed exercise support implemented locally; Garmin/watch validation pending
-- Next: Run a logged-in parse/preview test with real app environment values, then push one timed workout to Garmin for acceptance testing
+- Next: Sync the pushed workout to the watch and confirm timed intervals/custom rests appear correctly
 
 ## Active Plan (May 19)
 
@@ -18,8 +18,8 @@ Public web app to plan strength workouts with AI, push to Garmin watch, track pr
 - Confirmed scope: per-exercise custom rest, simple seconds/minutes timed exercises only, real Garmin validation before release.
 - Payload note: use the app's existing working Garmin constants as source of truth (`reps` = 10, `time` = 2, `lap.button` = 7); do not follow conflicting condition ID notes from older research without a golden-master payload.
 - Implemented locally: parser prompt/normalizer, Reps/Time/Distance preview controls, per-exercise rest seconds, timed Garmin payload builders, planned-vs-actual display, lint cleanup, changelog entry.
-- Verification completed: `npm run lint`, `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-key GEMINI_API_KEY=dummy-gemini-key PYTHON_API_URL=http://localhost:8000 npm run build`, `.venv/bin/python -m py_compile src/*.py`, local `/workout/new` HTTP 200 via `npm run dev -- --webpack`, Chrome smoke test for the workout builder, and backend payload fixture check for reps/time/distance/custom-rest/zero-rest.
-- Validation still needed before release: logged-in parser preview using real environment values, then real Garmin push/watch test for a timed strength interval using `endCondition: time`.
+- Verification completed: `npm run lint`, `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-key GEMINI_API_KEY=dummy-gemini-key PYTHON_API_URL=http://localhost:8000 npm run build`, `.venv/bin/python -m py_compile src/*.py`, local `/workout/new` HTTP 200 via `npm run dev -- --webpack`, Chrome smoke test for the workout builder, backend payload fixture check for reps/time/distance/custom-rest/zero-rest, Vercel preview parse test, and successful Garmin Connect push of `Timed Rest Test`.
+- Validation still needed before release: sync the pushed workout to the watch and confirm timed work intervals plus custom rest durations render correctly.
 
 ## Documentation Consolidation (Jan 23)
 - Updated CHECKLIST.md - Phase 3, 4, Deployment all marked complete (was stale)

--- a/thoughts/shared/plans/2026-05-19-custom-rest-and-timed-exercises.md
+++ b/thoughts/shared/plans/2026-05-19-custom-rest-and-timed-exercises.md
@@ -1,0 +1,134 @@
+# Custom Rest Periods and Timed Exercises Plan
+
+**Overall Progress:** `85%`
+
+## TLDR
+
+Add support for user-entered rest periods and timed exercises in the workout generator. The app already has rest defaults and fixed rest dropdowns, but this plan makes rest values fully editable and lets users generate exercises like `plank 3x45 sec`, `wall sit 4x1 min`, or `battle rope 6x30 sec` and push them to Garmin as time-based strength intervals.
+
+## Customer Impact
+
+- Users can write workouts more naturally without changing timed work into fake reps.
+- The preview can show and edit reps, time, or distance before pushing.
+- Garmin watch guidance should count timed work as a timed interval, with normal rest after each set.
+
+## Current Behavior
+
+- The parser asks Gemini for `rest_seconds` and defaults to 90 seconds.
+- The workout page applies saved major/minor rest defaults after parsing.
+- Each exercise row has editable sets, reps/distance, weight, and a fixed rest dropdown.
+- Distance mode exists for carries and uses Garmin lap-button behavior.
+- Activity display already knows how to show completed duration data, but planned workouts only model reps.
+
+## Critical Decisions
+
+- Decision 1: Add an explicit exercise target mode: `reps`, `time`, or `distance` - avoids guessing from partially populated fields.
+- Decision 2: Store timed planned exercises with `duration_seconds` - matches existing completed activity display and clipboard export language.
+- Decision 3: Use the app's existing Garmin condition constants as source of truth: `reps` = `{ conditionTypeId: 10, conditionTypeKey: 'reps' }`, `time` = `{ conditionTypeId: 2, conditionTypeKey: 'time' }`, `lap.button` = `{ conditionTypeId: 7, conditionTypeKey: 'lap.button' }`. These are already used in the current working workout builder.
+- Decision 4: Use Garmin interval steps with `endCondition: time` for timed exercises - the same condition object is already used for successful rest timers, but interval-time must still pass a real Garmin push/watch test before release.
+- Decision 5: Keep saved default rest settings as defaults only - parsing explicit rest text or editing a row should override the default.
+- Decision 6: Custom rest means per-exercise rest in the preview for v1.
+- Decision 7: Timed exercises mean simple seconds/minutes only for v1, such as `30s`, `45 sec`, or `1 min`. Do not add EMOM, AMRAP, or intervals yet.
+- Decision 8: Do a real Garmin validation before calling the feature ready.
+
+## Resolved Questions
+
+- Custom rest periods are per exercise in the generated workout preview.
+- Timed exercises support simple seconds/minutes only in v1.
+- Distance and time are separate modes in v1; no combined time-plus-distance targets.
+
+## Confidence Notes
+
+- App-side model, parser, UI, saving, and comparison changes are fully scoped.
+- Garmin reps, rest-time, and lap-button behavior are grounded in the current working app code.
+- The only thing that cannot be 100% proven from code inspection is whether Garmin accepts a time-based `interval` step exactly the same way it accepts a time-based `rest` step. The release gate is a real Garmin push/watch test.
+- If Garmin Connect Web is available during implementation, capture a manual timed strength workout payload as a golden master before finalizing the JSON builder.
+
+## Tasks:
+
+- [x] 🟩 **Step 1: Explore Current Generator Behavior**
+  - [x] 🟩 Confirm parser currently returns `rest_seconds` but not `duration_seconds`.
+  - [x] 🟩 Confirm preview row supports reps/distance only.
+  - [x] 🟩 Confirm Garmin payload builder currently supports reps and distance/lap-button only.
+  - [x] 🟩 Confirm activity detail already displays completed timed sets.
+  - [x] 🟩 Confirm per-exercise rest and simple timed durations are the v1 scope.
+  - [x] 🟩 Confirm real Garmin validation is required before release.
+
+- [x] 🟩 **Step 2: Extend Planned Exercise Shape**
+  - [x] 🟩 Add `target_type?: 'reps' | 'time' | 'distance'` to the frontend `Exercise` type.
+  - [x] 🟩 Add `duration_seconds?: number` for timed exercises.
+  - [x] 🟩 Update `PlannedExercise` on the activity detail page to understand timed planned work.
+  - [x] 🟩 Mirror the same fields in `src/schemas.py` so the backend builder stays aligned.
+
+- [x] 🟩 **Step 3: Teach the Parser Timed Exercise Syntax**
+  - [x] 🟩 Update the Gemini parse prompt to output `target_type` and `duration_seconds`.
+  - [x] 🟩 Support common examples: `plank 3x45 sec`, `wall sit 4x1 min`, `battle ropes 8x30s`, `dead hang 3x60 seconds`.
+  - [x] 🟩 Keep reps as the default when no time or distance is present.
+  - [x] 🟩 Preserve current exercise alias and Garmin matching behavior.
+
+- [x] 🟩 **Step 4: Make Rest Truly Custom**
+  - [x] 🟩 Replace or augment the fixed rest dropdown with a compact number input for seconds/minutes.
+  - [x] 🟩 Keep quick-pick options for common rests if they do not clutter the row.
+  - [x] 🟩 Make explicit parsed rest values override saved major/minor defaults.
+  - [x] 🟩 Keep saved default rest settings working exactly as they do today.
+
+- [x] 🟩 **Step 5: Add Time Mode to the Preview Row**
+  - [x] 🟩 Replace the reps/distance toggle with a small Reps / Time / Distance control.
+  - [x] 🟩 Show duration input in time mode, using seconds internally.
+  - [x] 🟩 Keep distance input in yards while storing meters internally.
+  - [ ] 🟥 Ensure mobile row layout still fits without overlapping text.
+
+- [x] 🟩 **Step 6: Build Garmin Timed Workout Payloads**
+  - [x] 🟩 Update `buildGarminWorkout()` to use `endCondition: { conditionTypeId: 2, conditionTypeKey: 'time' }` for timed exercise intervals.
+  - [x] 🟩 Set `endConditionValue` to `duration_seconds`.
+  - [x] 🟩 Keep rest steps unchanged after each interval.
+  - [x] 🟩 Update the backend `build_workout_json()` the same way for consistency.
+  - [x] 🟩 Pull Garmin condition objects into named constants so reps/time/lap-button stay consistent across exercise and rest steps.
+  - [x] 🟩 Preserve integer casting for Garmin IDs and numeric values.
+
+- [x] 🟩 **Step 7: Update Saved Workout and Comparison Displays**
+  - [x] 🟩 Save timed planned exercises in the existing `workouts.exercises` JSON.
+  - [x] 🟩 Show planned timed targets on the activity detail comparison page.
+  - [x] 🟩 Keep completed activity display and copy-to-clipboard behavior working for timed sets.
+
+- [ ] 🟨 **Step 8: Validate Locally**
+  - [x] 🟩 Run frontend lint/build checks after excluding or fixing existing generated-PWA lint noise.
+  - [x] 🟩 Run backend compile check with `.venv/bin/python -m py_compile src/*.py`.
+  - [x] 🟩 Confirm `/workout/new` returns HTTP 200 from the local dev server.
+  - [x] 🟩 Smoke-test `/workout/new` in Chrome with a mixed reps/time/distance/custom-rest input; page loads and Parse Workout enables.
+  - [x] 🟩 Verify backend Garmin payload shape for reps, timed intervals, lap-button distance work, custom rest, and zero-rest.
+  - [ ] 🟥 Test parse and preview manually with reps, custom rest, timed, and distance examples.
+
+- [ ] 🟥 **Step 9: Validate With Garmin**
+  - [ ] 🟥 If possible, manually create a timed strength workout in Garmin Connect Web and compare its payload to the app payload.
+  - [ ] 🟥 Push one timed workout to Garmin Connect using a real Garmin account.
+  - [ ] 🟥 Confirm the watch shows a timed work interval, not fake reps.
+  - [ ] 🟥 Confirm custom rest appears correctly between sets.
+  - [ ] 🟥 Sync the completed workout back and verify duration displays correctly.
+
+- [ ] 🟨 **Step 10: Document and Release**
+  - [x] 🟩 Update `CHANGELOG.md`.
+  - [ ] 🟥 Update user-facing docs if the input examples change.
+  - [x] 🟩 Update the continuity ledger after implementation and verification.
+
+## Suggested Test Inputs
+
+```text
+Core Day
+Plank 3x45 sec, rest 30 sec
+Side plank 2x30 sec each side, rest 20 sec
+Dead hang 3x60 seconds, rest 90 sec
+```
+
+```text
+Conditioning Finisher
+Battle ropes 8x30s @ 0 lbs, rest 30s
+Farmer's carry 4x40 yards @ 70 lbs, rest 60s
+Push ups 3x15, rest 45s
+```
+
+## Risk Notes
+
+- Garmin time-based strength intervals need real-device validation because this project uses reverse-engineered Garmin payloads.
+- The current frontend lint command fails on existing generated PWA files and the icon script; clean verification may require excluding generated files or fixing that script first.
+- Existing saved workouts may not have `target_type`; the implementation should infer `reps` when the field is missing.

--- a/thoughts/shared/plans/2026-05-19-custom-rest-and-timed-exercises.md
+++ b/thoughts/shared/plans/2026-05-19-custom-rest-and-timed-exercises.md
@@ -1,6 +1,6 @@
 # Custom Rest Periods and Timed Exercises Plan
 
-**Overall Progress:** `85%`
+**Overall Progress:** `90%`
 
 ## TLDR
 
@@ -101,7 +101,7 @@ Add support for user-entered rest periods and timed exercises in the workout gen
 
 - [ ] 🟥 **Step 9: Validate With Garmin**
   - [ ] 🟥 If possible, manually create a timed strength workout in Garmin Connect Web and compare its payload to the app payload.
-  - [ ] 🟥 Push one timed workout to Garmin Connect using a real Garmin account.
+  - [x] 🟩 Push one timed workout to Garmin Connect using a real Garmin account.
   - [ ] 🟥 Confirm the watch shows a timed work interval, not fake reps.
   - [ ] 🟥 Confirm custom rest appears correctly between sets.
   - [ ] 🟥 Sync the completed workout back and verify duration displays correctly.


### PR DESCRIPTION
## Summary
- Adds per-exercise custom rest editing in workout preview
- Adds Reps / Time / Distance target modes for generated exercises
- Sends timed exercises as Garmin time-based strength intervals while preserving existing reps and distance behavior

## Testing
- npm run lint
- npm run build with required environment placeholders
- .venv/bin/python -m py_compile src/*.py
- Chrome smoke test for /workout/new
- Backend payload fixture check for reps/time/distance/custom-rest/zero-rest

## Release gate
- Real Garmin watch validation is still required before merging to production.